### PR TITLE
adds events listing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "wpackagist-plugin/wp-action-network": "^1.1",
     "ggamel/wp-sync-db": "dev-master",
     "wpackagist-plugin/events-manager-wpml": "1.2",
-    "wpackagist-plugin/wordpress-seo": "^11.0"
+    "wpackagist-plugin/wordpress-seo": "^11.0",
+    "wpackagist-plugin/import-meetup-events": "^1.4"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4242a5d4f553b7d43233fc7a803656e8",
+    "content-hash": "1c0d5fcbb9e63aa8906ff6bdc1b9d093",
     "packages": [
         {
             "name": "composer/installers",
@@ -705,16 +705,34 @@
             "homepage": "https://wordpress.org/plugins/flickr-viewer/"
         },
         {
-            "name": "wpackagist-plugin/open-external-links-in-a-new-window",
-            "version": "1.3.2",
+            "name": "wpackagist-plugin/import-meetup-events",
+            "version": "1.4.1",
             "source": {
                 "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/open-external-links-in-a-new-window/",
-                "reference": "tags/1.3.2"
+                "url": "https://plugins.svn.wordpress.org/import-meetup-events/",
+                "reference": "tags/1.4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/open-external-links-in-a-new-window.1.3.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/import-meetup-events.1.4.1.zip"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/import-meetup-events/"
+        },
+        {
+            "name": "wpackagist-plugin/open-external-links-in-a-new-window",
+            "version": "1.4",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/open-external-links-in-a-new-window/",
+                "reference": "tags/1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/open-external-links-in-a-new-window.1.4.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -108,39 +108,35 @@ get_header(); ?>
 							</div>
 						</a>
 					</div>
-				<?php endwhile;
-
-				?>
-				</div>
-				<nav class="pages my-5">
-					<?php
-					// Pagination
-					$big = 999999999;
-					$pagination = paginate_links(array(
-						'base' => str_replace($big, '%#%', esc_url(get_pagenum_link($big))),
-						'current' => max(1, $paged),
-						'total' => $events->max_num_pages,
-						'type' => 'array',
-						'prev_text' => '&laquo; Previous',
-						'next_text' => 'Next &raquo;',
-					));
-					?>
-					<?php if ( ! empty( $pagination ) ) : ?>
-						<ul class="pagination justify-content-center">
-							<?php foreach ( $pagination as $key => $page_link ) : ?>
-								<li class="page-item <?php if ( strpos( $page_link, 'current' ) !== false ) { echo ' active'; } ?>">
-									<?php echo $page_link ?>
-								</li>
-							<?php endforeach ?>
-						</ul>
-					<?php endif ?>
-				</div>
+				<?php endwhile; ?>
+			</div>
+			<nav class="pages my-5">
 				<?php
-			// If no content, include the "No posts found" template.
-			else :
-				_e('Looks like there are no events, try clearing the filter and make sure to check Facebook or Meetup');
-			endif;
-			?>
+				// Pagination
+				$big = 999999999;
+				$pagination = paginate_links(array(
+					'base' => str_replace($big, '%#%', esc_url(get_pagenum_link($big))),
+					'current' => max(1, $paged),
+					'total' => $events->max_num_pages,
+					'type' => 'array',
+					'prev_text' => '&laquo; Previous',
+					'next_text' => 'Next &raquo;',
+				));
+				?>
+				<?php if ( ! empty( $pagination ) ) : ?>
+					<ul class="pagination justify-content-center">
+						<?php foreach ( $pagination as $key => $page_link ) : ?>
+							<li class="page-item <?php if ( strpos( $page_link, 'current' ) !== false ) { echo ' active'; } ?>">
+								<?php echo $page_link ?>
+							</li>
+						<?php endforeach ?>
+					</ul>
+				<?php endif ?>
+			</nav>
+			<?php _e('Check <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> or <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a> for latest events') ?>.
+		<?php else :
+			_e('Looks like there are no events, try clearing the filter and make sure to check <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> or <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a>');
+		endif; ?>
 	</div>
 </div>
 

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -43,9 +43,9 @@ get_header(); ?>
 	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_city ?></h1>
 
   <?php if ($cities) { ?>
-    <form class="form-inline mt-4" method="get">
+    <form class="form-inline mt-4 flex-nowrap" method="get">
       <label class="my-1 mr-2" for="city">City</label>
-      <select name="city" class="custom-select my-1 mr-sm-2" id="city">
+      <select name="city" class="custom-select my-1" id="city">
         <option value=""><?php _e('All') ?></option>
         <?php foreach($cities as $city) { ?>
           <option value="<?php echo $city->meta_value ?>" <?php echo $param_city == $city->meta_value ? 'selected="selected"' : '' ?>>
@@ -53,7 +53,7 @@ get_header(); ?>
           </option>
         <?php } ?>
       </select>
-      <button type="submit" class="btn btn-black">
+      <button type="submit" class="btn btn-black ml-2">
         <?php _e('Apply') ?>
       </button>
     </form>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -36,18 +36,18 @@ $args = array(
 	)
 );
 $events = new WP_Query( $args );
-
+$cities = event_cities();
 get_header(); ?>
 
 <div class="container my-5">
 	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_city ?></h1>
 
-  <?php if (event_cities()) { ?>
+  <?php if ($cities) { ?>
     <form class="form-inline mt-4" method="get">
       <label class="my-1 mr-2" for="city">City</label>
       <select name="city" class="custom-select my-1 mr-sm-2" id="city">
         <option value=""><?php _e('All') ?></option>
-        <?php foreach(event_cities() as $city) { ?>
+        <?php foreach($cities as $city) { ?>
           <option value="<?php echo $city->meta_value ?>" <?php echo $param_city == $city->meta_value ? 'selected="selected"' : '' ?>>
             <?php echo $city->meta_value ?>
           </option>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -8,8 +8,17 @@ $args = array(
 	'posts_per_page' => 10,
 	'paged' => $paged,
 	'post_type' => 'meetup_events',
-	'orderby' => 'event_start_date',
-	'order' => 'ASC'
+	'orderby' => 'meta_value',
+	'meta_key' => 'event_start_date',
+	'order' => 'ASC',
+	'meta_query' => array(
+		array(
+			'key' => 'event_start_date', // Check the start date field
+			'value' => date("Y-m-d"), // Set today's date (note the similar format)
+			'compare' => '>=', // Return the ones greater than today's date
+			'type' => 'DATE' // Let WordPress know we're working with date
+		)
+	)
 );
 $events = new WP_Query( $args );
 
@@ -27,7 +36,7 @@ get_header(); ?>
 					if( $event_date != '' ){
 						$event_date = strtotime( $event_date );
 					}
-					$event_address = get_post_meta( get_the_ID(), 'venue_name', true );
+					$event_address = get_post_meta( get_the_ID(), 'venue_city', true );
 					$venue_address = get_post_meta( get_the_ID(), 'venue_address', true );
 					if( $event_address != '' && $venue_address != '' ){
 						$event_address .= ' - '.$venue_address;

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -45,6 +45,7 @@ get_header(); ?>
   <?php if ($cities) { ?>
     <form class="form-inline mt-4 flex-nowrap" method="get">
       <label class="my-1 mr-2" for="city">City</label>
+			<input type="hidden" name="paged" value="1" />
       <select name="city" class="custom-select my-1" id="city">
         <option value=""><?php _e('All') ?></option>
         <?php foreach($cities as $city) { ?>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Template name: Events
+ */
+
+$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+$args = array(
+	'posts_per_page' => 10,
+	'paged' => $paged,
+	'post_type' => 'meetup_events',
+	'orderby' => 'event_start_date',
+	'order' => 'ASC'
+);
+$events = new WP_Query( $args );
+
+get_header(); ?>
+
+<div class="container my-5">
+	<h1 class="page-title"><?php _e('EVENTS'); ?></h1>
+
+	<div class="mt-4">
+		<?php if ( $events->have_posts() ) : ?>
+			<div class="row">
+				<?php while ( $events->have_posts() ) : $events->the_post(); ?>
+					<?php
+					$event_date = get_post_meta( get_the_ID(), 'event_start_date', true );
+					if( $event_date != '' ){
+						$event_date = strtotime( $event_date );
+					}
+					$event_address = get_post_meta( get_the_ID(), 'venue_name', true );
+					$venue_address = get_post_meta( get_the_ID(), 'venue_address', true );
+					if( $event_address != '' && $venue_address != '' ){
+						$event_address .= ' - '.$venue_address;
+					}elseif( $venue_address != '' ){
+						$event_address = $venue_address;
+					}
+
+					$image_url =  array();
+					if ( '' !== get_the_post_thumbnail() ){
+						$image_url =  wp_get_attachment_image_src( get_post_thumbnail_id(  get_the_ID() ), 'full' );
+					}else{
+						$image_date = date_i18n('F+d', $event_date );
+						$image_url[] =  "http://placehold.it/420x150?text=".$image_date;
+					}
+					?>
+					<div class="col-md-6 my-3">
+						<a href="<?php echo esc_url( get_permalink() ) ?>">
+							<div class="<?php echo $css_class; ?> archive-event">
+								<div class="ime_event" >
+									<div class="img_placeholder" style=" background: url('<?php echo $image_url[0]; ?>') no-repeat left top;"></div>
+									<div class="event_details">
+										<div class="event_date">
+											<span class="month"><?php echo date_i18n('M', $event_date) ; ?></span>
+											<span class="date"> <?php echo date_i18n('d', $event_date) ; ?> </span>
+										</div>
+										<div class="event_desc">
+											<a href="<?php echo esc_url( get_permalink() ) ?>" rel="bookmark">
+											<?php the_title( '<div class="event_title">','</div>' ); ?>
+											</a>
+											<?php if( $event_address != '' ){ ?>
+												<div class="event_address"><i class="fa fa-map-marker"></i> <?php echo $event_address; ?></div>
+											<?php }	?>
+										</div>
+										<div style="clear: both"></div>
+									</div>
+								</div>
+							</div>
+						</a>
+					</div>
+				<?php endwhile;
+
+				?>
+				</div>
+				<nav class="pages my-5">
+					<?php
+					// Pagination
+					$big = 999999999;
+					$pagination = paginate_links(array(
+						'base' => str_replace($big, '%#%', esc_url(get_pagenum_link($big))),
+						'current' => max(1, $paged),
+						'total' => $events->max_num_pages,
+						'type' => 'array',
+						'prev_text' => '&laquo; Previous',
+						'next_text' => 'Next &raquo;',
+					));
+					?>
+					<?php if ( ! empty( $pagination ) ) : ?>
+						<ul class="pagination justify-content-center">
+							<?php foreach ( $pagination as $key => $page_link ) : ?>
+								<li class="page-item <?php if ( strpos( $page_link, 'current' ) !== false ) { echo ' active'; } ?>">
+									<?php echo $page_link ?>
+								</li>
+							<?php endforeach ?>
+						</ul>
+					<?php endif ?>
+				</div>
+				<?php
+			// If no content, include the "No posts found" template.
+			else :
+				get_template_part( 'template-parts/content', 'none' );
+			endif;
+			?>
+	</div>
+</div>
+
+<?php get_footer(); ?>
+

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -3,7 +3,20 @@
  * Template name: Events
  */
 
+// city query param
+$param_city = get_query_var('city');
+
+// city query
+$query_city = $param_city ? array(
+  'key' => 'venue_city',
+  'value' => $param_city,
+  'compare' => '='
+) : array();
+
+// page query param
 $paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+
+// Events Query
 $args = array(
 	'posts_per_page' => 10,
 	'paged' => $paged,
@@ -17,7 +30,9 @@ $args = array(
 			'value' => date("Y-m-d"), // Set today's date (note the similar format)
 			'compare' => '>=', // Return the ones greater than today's date
 			'type' => 'DATE' // Let WordPress know we're working with date
-		)
+    ),
+    // adds city filter
+    $query_city
 	)
 );
 $events = new WP_Query( $args );
@@ -25,7 +40,24 @@ $events = new WP_Query( $args );
 get_header(); ?>
 
 <div class="container my-5">
-	<h1 class="page-title"><?php _e('EVENTS'); ?></h1>
+	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_city ?></h1>
+
+  <?php if (event_cities()) { ?>
+    <form class="form-inline mt-4" method="get">
+      <label class="my-1 mr-2" for="city">City</label>
+      <select name="city" class="custom-select my-1 mr-sm-2" id="city">
+        <option value=""><?php _e('All') ?></option>
+        <?php foreach(event_cities() as $city) { ?>
+          <option value="<?php echo $city->meta_value ?>" <?php echo $param_city == $city->meta_value ? 'selected="selected"' : '' ?>>
+            <?php echo $city->meta_value ?>
+          </option>
+        <?php } ?>
+      </select>
+      <button type="submit" class="btn btn-black">
+        <?php _e('Apply') ?>
+      </button>
+    </form>
+  <?php } ?>
 
 	<div class="mt-4">
 		<?php if ( $events->have_posts() ) : ?>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -138,7 +138,7 @@ get_header(); ?>
 				<?php
 			// If no content, include the "No posts found" template.
 			else :
-				get_template_part( 'template-parts/content', 'none' );
+				_e('Looks like there are no events, try clearing the filter and make sure to check Facebook or Meetup');
 			endif;
 			?>
 	</div>

--- a/web/app/themes/xrnl/assets/sass/_variables.scss
+++ b/web/app/themes/xrnl/assets/sass/_variables.scss
@@ -2,11 +2,11 @@
 $theme-colors: (
   "primary": #21a73d,
   "green": #21a73d,
-  "yellow": #F4F07A,
+  "yellow": #ffc113,
   "pink": #ed9bc4,
   "red": #dc4f00,
-  "orange": #FFC113,
-  "blue": #75D0F1,
+  "orange": #f19631,
+  "blue": #75d0f1,
   "black": #000,
   "white": #fff
 ) !default;

--- a/web/app/themes/xrnl/assets/sass/_variables.scss
+++ b/web/app/themes/xrnl/assets/sass/_variables.scss
@@ -2,11 +2,11 @@
 $theme-colors: (
   "primary": #21a73d,
   "green": #21a73d,
-  "yellow": #ffc113,
+  "yellow": #F4F07A,
   "pink": #ed9bc4,
   "red": #dc4f00,
-  "orange": #f19631,
-  "blue": #75d0f1,
+  "orange": #FFC113,
+  "blue": #75D0F1,
   "black": #000,
   "white": #fff
 ) !default;

--- a/web/app/themes/xrnl/assets/sass/app.scss
+++ b/web/app/themes/xrnl/assets/sass/app.scss
@@ -8,5 +8,6 @@
 @import "list";
 @import "form";
 @import "press";
+@import "events";
 @import "custom";
 @import "rwb";

--- a/web/app/themes/xrnl/assets/sass/custom.scss
+++ b/web/app/themes/xrnl/assets/sass/custom.scss
@@ -128,8 +128,18 @@ nav.pagination.navigation {
   }
 }
 
-// Post navigation
-
+// Post, page navigation
+nav.pages > ul.pagination > li.page-item {
+  span {
+    @extend .page-link;
+  }
+  a {
+    @extend .page-link;
+    text-decoration: none !important;
+    color: map-get($theme-colors, 'green') !important;
+  }
+}
+nav.pagination,
 nav.post-navigation {
   @extend .mb-4;
   @extend .mb-sm-5;
@@ -144,8 +154,9 @@ nav.post-navigation {
     &> :nth-child(2) {
       @extend .border-top;
     }
-    a {
-      text-decoration: none;
+    a.page-numbers {
+      text-decoration: none !important;
+      color: map-get($theme-colors, 'green') !important;
       span {
         color: #999;
       }

--- a/web/app/themes/xrnl/assets/sass/events.scss
+++ b/web/app/themes/xrnl/assets/sass/events.scss
@@ -4,7 +4,7 @@
 }
 
 .event_details {
-  background: map-get($theme-colors, 'blue') !important;
+  background: map-get($theme-colors, 'yellow') !important;
 }
 
 .img_placeholder {

--- a/web/app/themes/xrnl/assets/sass/events.scss
+++ b/web/app/themes/xrnl/assets/sass/events.scss
@@ -1,0 +1,30 @@
+
+.archive-event .ime_event {
+  height: auto !important;
+}
+
+.event_details {
+  background: map-get($theme-colors, 'orange') !important;
+}
+
+.img_placeholder {
+  min-height: 230px !important;
+}
+
+.event_desc {
+  padding: 10px 15px !important;
+  width: calc(100% - 100px) !important;
+  a {
+    color: #000 !important;
+    @extend .text-reset;
+    .event_title {
+      color: #000;
+    }
+  }
+}
+
+.event_date {
+  background: #000 !important;
+  color: #fff !important;
+  width: 100px !important;
+}

--- a/web/app/themes/xrnl/assets/sass/events.scss
+++ b/web/app/themes/xrnl/assets/sass/events.scss
@@ -28,3 +28,14 @@
   color: #fff !important;
   width: 100px !important;
 }
+
+.col-ime-md-6 {
+  margin-bottom: 3% !important;
+  @include media-breakpoint-down(md) {
+    margin-bottom: 5% !important;
+  }
+  @include media-breakpoint-down(sm) {
+    margin-bottom: 6% !important;
+  }
+}
+

--- a/web/app/themes/xrnl/assets/sass/events.scss
+++ b/web/app/themes/xrnl/assets/sass/events.scss
@@ -4,7 +4,7 @@
 }
 
 .event_details {
-  background: map-get($theme-colors, 'orange') !important;
+  background: map-get($theme-colors, 'blue') !important;
 }
 
 .img_placeholder {

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -43,7 +43,7 @@
 <div class="container-fluid">
     <a name="details"></a>
     <div class="row text-center">
-        <a href="<?php echo (ICL_LANGUAGE_CODE === "nl") ? "" : "/en"; ?>/talk" class="col-12 col-xl-6 bg-yellow p-4 py-5 text-decoration-none">
+        <a href="<?php echo (ICL_LANGUAGE_CODE === "nl") ? "" : "/en"; ?>/talk" class="col-12 col-xl-6 bg-orange p-4 py-5 text-decoration-none">
             <i class="fab fa-youtube fa-3x text-black"></i>
             <h2 class="text-black mt-3"><?php echo (ICL_LANGUAGE_CODE === "nl") ? "Bekijk de Extinction Rebellion Talk" : "Watch the Extinction Rebellion Talk"; ?></h2>
         </a>

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -1,4 +1,6 @@
 <?PHP
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
 add_theme_support("post-thumbnails");
 add_theme_support("custom-logo");
 add_theme_support( 'title-tag' );
@@ -131,16 +133,16 @@ function add_og_image() {
 add_action( 'wp_head', 'add_og_image' );
 
 // Make sure events details page has `/events/:slug` url instead of `/meetup-event/:slug`
-
-class CustomMeetupEventCpt extends Import_Meetup_Events_Cpt {
-    public function __construct() {
-        parent::__construct();
-        $this->event_slug = 'events';
+if (is_plugin_active('import-meetup-events/import-meetup-events.php')) {
+    class CustomMeetupEventCpt extends Import_Meetup_Events_Cpt {
+        public function __construct() {
+            parent::__construct();
+            $this->event_slug = 'events';
+        }
     }
+
+    Import_Meetup_Events::instance()->cpt = new CustomMeetupEventCpt();
 }
-
-Import_Meetup_Events::instance()->cpt = new CustomMeetupEventCpt();
-
 
 // Get Distinct Event cities
 function event_cities() {

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -150,7 +150,8 @@ function event_cities() {
     return $wpdb->get_results("
         select distinct meta_value
         from $wpdb->postmeta
-        where meta_key = 'venue_city'
+        where meta_key = 'venue_city' and meta_value != ''
+        order by meta_value asc
     ");
 }
 

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -129,3 +129,14 @@ function add_og_image() {
     <?php }
 }
 add_action( 'wp_head', 'add_og_image' );
+
+// Make sure events details page has `/events/:slug` url instead of `/meetup-event/:slug`
+
+class CustomMeetupEventCpt extends Import_Meetup_Events_Cpt {
+    public function __construct() {
+        parent::__construct();
+        $this->event_slug = 'events';
+    }
+}
+
+Import_Meetup_Events::instance()->cpt = new CustomMeetupEventCpt();

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -140,3 +140,21 @@ class CustomMeetupEventCpt extends Import_Meetup_Events_Cpt {
 }
 
 Import_Meetup_Events::instance()->cpt = new CustomMeetupEventCpt();
+
+
+// Get Distinct Event cities
+function event_cities() {
+    global $wpdb;
+    return $wpdb->get_results("
+        select distinct meta_value
+        from $wpdb->postmeta
+        where meta_key = 'venue_city'
+    ");
+}
+
+// Add city query var to filter on events page
+function xrnl_query_vars( $qvars ) {
+    $qvars[] = 'city';
+    return $qvars;
+}
+add_filter( 'query_vars', 'xrnl_query_vars' );

--- a/web/app/themes/xrnl/header.php
+++ b/web/app/themes/xrnl/header.php
@@ -35,25 +35,27 @@
                     'walker'          => new WP_Bootstrap_Navwalker(),
                 ] ); ?>
 
-                <?php wp_nav_menu( [
-                    'theme_location' => 'language',
-                    'container'       => '',
-                    'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
-                    'menu_class'      => 'navbar-nav language-menu ml-auto',
-                    'walker'          => new WP_Bootstrap_Navwalker(),
-                ] ); ?>
+                <div class="ml-auto d-flex">
+                    <?php wp_nav_menu( [
+                        'theme_location' => 'language',
+                        'container'       => '',
+                        'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+                        'menu_class'      => 'navbar-nav language-menu',
+                        'walker'          => new WP_Bootstrap_Navwalker(),
+                    ] ); ?>
 
-                <ul class="list-unstyled d-flex my-3 my-xl-0 align-items-center">
-                    <li class="mx-3 mx-lg-2">
-                        <a href="https://www.facebook.com/ExtinctionRebellionNL/" target="_blank" class="facebook" aria-label="facebook"><i class="fab text-black fa-facebook-f"></i></a></li>
-                    <li class="mx-3 mx-lg-2">
-                        <a href="https://twitter.com/nlrebellion" class="twitter" target="_blank" aria-label="twitter"><i class="fab text-black fa-twitter"></i></a></li>
-                    <li class="mx-3 mx-lg-2">
-                        <a href="https://www.instagram.com/extinctionrebellion/?hl=nl" target="_blank" class="insta" aria-label="instagram"><i class="fab text-black fa-instagram"></i></a></li>
-                    <li class="mx-3 mx-lg-2">
-                        <a href="/donate" class="btn btn-black"><?php _e('donate'); ?></a>
-                    </li>
-                </ul>
+                    <ul class="list-unstyled d-flex my-3 my-xl-0 align-items-center">
+                        <li class="mx-3 mx-lg-2">
+                            <a href="https://www.facebook.com/ExtinctionRebellionNL/" target="_blank" class="facebook" aria-label="facebook"><i class="fab text-black fa-facebook-f"></i></a></li>
+                        <li class="mx-3 mx-lg-2">
+                            <a href="https://twitter.com/nlrebellion" class="twitter" target="_blank" aria-label="twitter"><i class="fab text-black fa-twitter"></i></a></li>
+                        <li class="mx-3 mx-lg-2">
+                            <a href="https://www.instagram.com/extinctionrebellion/?hl=nl" target="_blank" class="insta" aria-label="instagram"><i class="fab text-black fa-instagram"></i></a></li>
+                        <li class="mx-3 mx-lg-2">
+                            <a href="/donate" class="btn btn-black"><?php _e('donate'); ?></a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </nav>
     </header>


### PR DESCRIPTION
Closes #8 

This PR adds import-meetup-events plugin which gets all events from meetup. 

Todo after merge:
- [ ] Enable the plugin
- [ ] Go to `Settings` > `Permalinks` and press "save"
- [ ] Update events manager slug settings from `events` to point to `events-old` (This is because we already have a hidden events listing page which is only accessible by url or search engines https://extinctionrebellion.nl/events/page/2/ which conflicts with this change)
    <img width="200" alt="Screenshot 2019-08-18 at 12 54 13" src="https://user-images.githubusercontent.com/123815/63223535-57ef7e80-c1b7-11e9-8c9d-56d04aee2217.png">
- [ ] Authorize meetup with Oauth and import events

**Screenshots:**

<img src="https://user-images.githubusercontent.com/123815/63223475-71dc9180-c1b6-11e9-8fea-2c191e666f71.jpg" width="150" /> <img src="https://user-images.githubusercontent.com/123815/63223478-7c972680-c1b6-11e9-8662-b0b41a2da592.png" width="150" /> <img width="150" alt="Screenshot 2019-08-24 at 02 06 11" src="https://user-images.githubusercontent.com/123815/63629719-1bd37800-c614-11e9-865a-65abb5ddc742.png">